### PR TITLE
fix issue with daylight saving time change

### DIFF
--- a/easyenergy/easyenergy.py
+++ b/easyenergy/easyenergy.py
@@ -219,30 +219,31 @@ class EasyEnergy:
         ------
             EasyEnergyNoDataError: No energy prices found for this period.
         """
-        # Set the start date to 23:00:00 previous day and the end date to 23:00:00 UTC
-        start_date_utc: datetime = datetime(
+        local_tz = datetime.now(timezone.utc).astimezone().tzinfo
+        # Set start_date to 00:00:00 and the end_date to 00:00:00 and convert to UTC
+        utc_start_date: datetime = datetime(
             start_date.year,
             start_date.month,
             start_date.day,
             0,
             0,
             0,
-            tzinfo=timezone.utc,
-        ) - timedelta(hours=1)
-        end_date_utc: datetime = datetime(
+            tzinfo=local_tz,
+        ).astimezone(timezone.utc)
+        utc_end_date: datetime = datetime(
             end_date.year,
             end_date.month,
             end_date.day,
-            23,
             0,
             0,
-            tzinfo=timezone.utc,
-        )
+            0,
+            tzinfo=local_tz,
+        ).astimezone(timezone.utc) + timedelta(days=1)
         data = await self._request(
             "getapxtariffs",
             params={
-                "startTimestamp": start_date_utc.strftime("%Y-%m-%dT%H:%M:%S.000Z"),
-                "endTimestamp": end_date_utc.strftime("%Y-%m-%dT%H:%M:%S.000Z"),
+                "startTimestamp": utc_start_date.strftime("%Y-%m-%dT%H:%M:%S.000Z"),
+                "endTimestamp": utc_end_date.strftime("%Y-%m-%dT%H:%M:%S.000Z"),
                 "includeVat": self.incl_vat.lower(),
             },
         )

--- a/easyenergy/easyenergy.py
+++ b/easyenergy/easyenergy.py
@@ -145,55 +145,56 @@ class EasyEnergy:
         ------
             EasyEnergyNoDataError: No gas prices found for this period.
         """
-        start_date_utc: datetime
-        end_date_utc: datetime
-        utcnow: datetime = datetime.now(timezone.utc)
-        if utcnow.hour >= 5 and utcnow.hour <= 22:
-            # Set start_date to 05:00:00 and the end_date to 05:00:00 UTC next day
-            start_date_utc = datetime(
-                start_date.year,
-                start_date.month,
-                start_date.day,
-                5,
-                0,
-                0,
-                tzinfo=timezone.utc,
-            )
-            end_date_utc = datetime(
-                end_date.year,
-                end_date.month,
-                end_date.day,
-                5,
-                0,
-                0,
-                tzinfo=timezone.utc,
-            ) + timedelta(days=1)
-        else:
-            # Set start_date to 05:00:00 prev day and the end_date to 05:00:00 UTC
-            start_date_utc = datetime(
-                start_date.year,
-                start_date.month,
-                start_date.day,
-                5,
-                0,
-                0,
-                tzinfo=timezone.utc,
-            ) - timedelta(days=1)
-            end_date_utc = datetime(
-                end_date.year,
-                end_date.month,
-                end_date.day,
-                5,
-                0,
-                0,
-                tzinfo=timezone.utc,
-            )
+        local_tz = datetime.now(timezone.utc).astimezone().tzinfo
+        now: datetime = datetime.now(tz=local_tz)
 
+        if now.hour >= 6 and now.hour <= 23:
+            # Set start_date to 06:00:00 and the end_date to 06:00:00 next day
+            # Convert to UTC time 04:00:00 and 04:00:00 next day
+            utc_start_date = datetime(
+                start_date.year,
+                start_date.month,
+                start_date.day,
+                6,
+                0,
+                0,
+                tzinfo=local_tz,
+            ).astimezone(timezone.utc)
+            utc_end_date = datetime(
+                end_date.year,
+                end_date.month,
+                end_date.day,
+                6,
+                0,
+                0,
+                tzinfo=local_tz,
+            ).astimezone(timezone.utc) + timedelta(days=1)
+        else:
+            # Set start_date to 06:00:00 prev day and the end_date to 06:00:00
+            # Convert to UTC time 04:00:00 prev day and 04:00:00 current day
+            utc_start_date = datetime(
+                start_date.year,
+                start_date.month,
+                start_date.day,
+                6,
+                0,
+                0,
+                tzinfo=local_tz,
+            ).astimezone(timezone.utc) - timedelta(days=1)
+            utc_end_date = datetime(
+                end_date.year,
+                end_date.month,
+                end_date.day,
+                6,
+                0,
+                0,
+                tzinfo=local_tz,
+            ).astimezone(timezone.utc)
         data = await self._request(
             "getlebatariffs",
             params={
-                "startTimestamp": start_date_utc.strftime("%Y-%m-%dT%H:%M:%S.000Z"),
-                "endTimestamp": end_date_utc.strftime("%Y-%m-%dT%H:%M:%S.000Z"),
+                "startTimestamp": utc_start_date.strftime("%Y-%m-%dT%H:%M:%S.000Z"),
+                "endTimestamp": utc_end_date.strftime("%Y-%m-%dT%H:%M:%S.000Z"),
                 "includeVat": self.incl_vat.lower(),
             },
         )

--- a/easyenergy/models.py
+++ b/easyenergy/models.py
@@ -23,7 +23,8 @@ def _timed_value(moment: datetime, prices: dict[datetime, float]) -> float | Non
     """
     value = None
     for timestamp, price in prices.items():
-        if timestamp <= moment < (timestamp + timedelta(hours=1)):
+        future_dt = timestamp + timedelta(hours=1)
+        if timestamp <= moment < future_dt:
             value = round(price, 5)
     return value
 

--- a/examples/energy.py
+++ b/examples/energy.py
@@ -12,8 +12,8 @@ async def main() -> None:
     """Show example on fetching the energy prices from easyEnergy."""
     async with EasyEnergy() as client:
         local = pytz.timezone("Europe/Amsterdam")
-        today = date(2023, 3, 12)
-        tomorrow = date(2023, 3, 13)
+        today = date(2023, 3, 28)
+        tomorrow = date(2023, 3, 29)
 
         # Select your test readings
         switch_e_today: bool = True
@@ -21,7 +21,7 @@ async def main() -> None:
 
         if switch_e_today:
             energy_today = await client.energy_prices(start_date=today, end_date=today)
-            next_hour = energy_today.utcnow() + timedelta(hours=1)
+            utc_next_hour = energy_today.utcnow() + timedelta(hours=1)
             print("--- ENERGY TODAY ---")
             print(f"Extremas usage price: {energy_today.extreme_usage_prices}")
             print(f"Extremas return price: {energy_today.extreme_return_prices}")
@@ -37,7 +37,7 @@ async def main() -> None:
             print()
             print(f"Current usage price: {energy_today.current_usage_price}")
             print(f"Current return price: {energy_today.current_return_price}")
-            print(f"Next hourprice: {energy_today.price_at_time(next_hour)}")
+            print(f"Next hourprice: {energy_today.price_at_time(utc_next_hour)}")
 
         if switch_e_tomorrow:
             energy_tomorrow = await client.energy_prices(tomorrow, tomorrow)

--- a/examples/gas.py
+++ b/examples/gas.py
@@ -9,7 +9,7 @@ from easyenergy import EasyEnergy
 async def main() -> None:
     """Show example on fetching the gas prices from easyEnergy."""
     async with EasyEnergy() as client:
-        today = date(2022, 12, 14)
+        today = date(2023, 3, 28)
 
         gas_today = await client.gas_prices(start_date=today, end_date=today)
         next_hour = gas_today.utcnow() + timedelta(hours=1)

--- a/tests/fixtures/energy.json
+++ b/tests/fixtures/energy.json
@@ -142,5 +142,11 @@
         "SupplierId": 0,
         "TariffUsage": 0.091930600000000000,
         "TariffReturn": 0.08434
+    },
+    {
+        "Timestamp": "2022-12-29T22:00:00+00:00",
+        "SupplierId": 0,
+        "TariffUsage": 0.039937600000000000,
+        "TariffReturn": 0.03664
     }
 ]

--- a/tests/fixtures/energy.json
+++ b/tests/fixtures/energy.json
@@ -1,5 +1,11 @@
 [
     {
+        "Timestamp": "2022-12-28T22:00:00+00:00",
+        "SupplierId": 0,
+        "TariffUsage": 0.023413200000000000,
+        "TariffReturn": 0.02148
+    },
+    {
         "Timestamp": "2022-12-28T23:00:00+00:00",
         "SupplierId": 0,
         "TariffUsage": -0.000882900000000000,
@@ -136,11 +142,5 @@
         "SupplierId": 0,
         "TariffUsage": 0.091930600000000000,
         "TariffReturn": 0.08434
-    },
-    {
-        "Timestamp": "2022-12-29T22:00:00+00:00",
-        "SupplierId": 0,
-        "TariffUsage": 0.039937600000000000,
-        "TariffReturn": 0.03664
     }
 ]

--- a/tests/fixtures/gas.json
+++ b/tests/fixtures/gas.json
@@ -1,5 +1,11 @@
 [
     {
+        "Timestamp": "2022-12-13T22:00:00+00:00",
+        "SupplierId": 0,
+        "TariffUsage": 1.464502200000000000,
+        "TariffReturn": 1.464502200000000000
+    },
+    {
         "Timestamp": "2022-12-13T23:00:00+00:00",
         "SupplierId": 0,
         "TariffUsage": 1.464502200000000000,
@@ -133,12 +139,6 @@
     },
     {
         "Timestamp": "2022-12-14T21:00:00+00:00",
-        "SupplierId": 0,
-        "TariffUsage": 1.485343000000000000,
-        "TariffReturn": 1.485343000000000000
-    },
-    {
-        "Timestamp": "2022-12-14T22:00:00+00:00",
         "SupplierId": 0,
         "TariffUsage": 1.485343000000000000,
         "TariffReturn": 1.485343000000000000

--- a/tests/fixtures/gas.json
+++ b/tests/fixtures/gas.json
@@ -142,5 +142,11 @@
         "SupplierId": 0,
         "TariffUsage": 1.485343000000000000,
         "TariffReturn": 1.485343000000000000
+    },
+    {
+        "Timestamp": "2022-12-14T22:00:00+00:00",
+        "SupplierId": 0,
+        "TariffUsage": 1.485343000000000000,
+        "TariffReturn": 1.485343000000000000
     }
 ]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -10,9 +10,9 @@ from easyenergy import EasyEnergy, EasyEnergyNoDataError, Electricity, Gas
 from . import load_fixtures
 
 
-@pytest.mark.freeze_time("2022-12-29 14:00:00 UTC")
+@pytest.mark.freeze_time("2022-12-29 15:00:00+01:00")
 async def test_electricity_model_usage(aresponses: ResponsesMockServer) -> None:
-    """Test the electricity model for usage at 14:00:00 UTC."""
+    """Test the electricity model for usage at 15:00:00 CET."""
     aresponses.add(
         "mijn.easyenergy.com",
         "/nl/api/tariff/getapxtariffs",
@@ -34,7 +34,7 @@ async def test_electricity_model_usage(aresponses: ResponsesMockServer) -> None:
         assert isinstance(energy, Electricity)
         assert energy.extreme_usage_prices[1] == 0.13345
         assert energy.extreme_usage_prices[0] == -0.00277
-        assert energy.average_usage_price == 0.07064
+        assert energy.average_usage_price == 0.06941
         assert energy.current_usage_price == 0.1199
         # The next hour price
         next_hour = datetime(2022, 12, 29, 15, 0, tzinfo=timezone.utc)
@@ -51,9 +51,9 @@ async def test_electricity_model_usage(aresponses: ResponsesMockServer) -> None:
         assert isinstance(energy.timestamp_usage_prices, list)
 
 
-@pytest.mark.freeze_time("2022-12-29 14:00:00 UTC")
+@pytest.mark.freeze_time("2022-12-29 15:00:00+01:00")
 async def test_electricity_model_return(aresponses: ResponsesMockServer) -> None:
-    """Test the electricity model for return at 14:00:00 UTC."""
+    """Test the electricity model for return at 15:00:00 CET."""
     aresponses.add(
         "mijn.easyenergy.com",
         "/nl/api/tariff/getapxtariffs",
@@ -75,7 +75,7 @@ async def test_electricity_model_return(aresponses: ResponsesMockServer) -> None
         assert isinstance(energy, Electricity)
         assert energy.extreme_return_prices[1] == 0.12243
         assert energy.extreme_return_prices[0] == -0.00254
-        assert energy.average_return_price == 0.06481
+        assert energy.average_return_price == 0.06368
         assert energy.current_return_price == 0.11
         # The next hour price
         next_hour = datetime(2022, 12, 29, 15, 0, tzinfo=timezone.utc)
@@ -139,7 +139,7 @@ async def test_electricity_none_data(aresponses: ResponsesMockServer) -> None:
         assert energy is not None
         assert isinstance(energy, Electricity)
         assert energy.current_return_price is None
-        assert energy.average_return_price == 0.06481
+        assert energy.average_return_price == 0.06368
 
 
 async def test_no_electricity_data(aresponses: ResponsesMockServer) -> None:
@@ -161,9 +161,9 @@ async def test_no_electricity_data(aresponses: ResponsesMockServer) -> None:
             await client.energy_prices(start_date=today, end_date=today)
 
 
-@pytest.mark.freeze_time("2022-12-14 14:00:00 UTC")
+@pytest.mark.freeze_time("2022-12-14 15:00:00+01:00")
 async def test_gas_model(aresponses: ResponsesMockServer) -> None:
-    """Test the gas model - easyEnergy at 14:00:00 UTC."""
+    """Test the gas model - easyEnergy at 15:00:00 CET."""
     aresponses.add(
         "mijn.easyenergy.com",
         "/nl/api/tariff/getlebatariffs",
@@ -182,13 +182,13 @@ async def test_gas_model(aresponses: ResponsesMockServer) -> None:
         assert isinstance(gas, Gas)
         assert gas.extreme_prices[1] == 1.48534
         assert gas.extreme_prices[0] == 1.4645
-        assert gas.average_price == 1.47926
+        assert gas.average_price == 1.47951
         assert gas.current_price == 1.48534
 
 
-@pytest.mark.freeze_time("2022-12-14 03:00:00 UTC")
+@pytest.mark.freeze_time("2022-12-14 04:00:00+01:00")
 async def test_gas_morning_model(aresponses: ResponsesMockServer) -> None:
-    """Test the gas model in the morning - easyEnergy at 03:00:00 UTC."""
+    """Test the gas model in the morning - easyEnergy at 04:00:00 CET."""
     aresponses.add(
         "mijn.easyenergy.com",
         "/nl/api/tariff/getlebatariffs",
@@ -207,7 +207,7 @@ async def test_gas_morning_model(aresponses: ResponsesMockServer) -> None:
         assert isinstance(gas, Gas)
         assert gas.extreme_prices[1] == 1.48534
         assert gas.extreme_prices[0] == 1.4645
-        assert gas.average_price == 1.47926
+        assert gas.average_price == 1.47951
         assert gas.current_price == 1.4645
 
 
@@ -230,7 +230,7 @@ async def test_gas_none_data(aresponses: ResponsesMockServer) -> None:
         assert gas is not None
         assert isinstance(gas, Gas)
         assert gas.current_price is None
-        assert gas.average_price == 1.47926
+        assert gas.average_price == 1.47951
 
 
 async def test_no_gas_data(aresponses: ResponsesMockServer) -> None:


### PR DESCRIPTION
Due to the transition to daylight saving time (CEST), problems have arisen in the API request due to the way the start and end date are composed in the code, this problem is mainly seen between 00:00 and 01:00 CEST. This is because the UTC offset has moved from 1 hour to 2 hours, so we do not request 1 hour of extra data from the API at that moment.

With this PR, a local datetime variable is converted to UTC and only then used in the request, instead of setting the variable to the correct times using `timedelta`.